### PR TITLE
Resolve d-krupke/slurminade#10

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The project is reasonably easy:
 
 ## Changes
 
+* 0.5.4: Dispatched function calls that are too long for the command line now use a temporary file instead.
 * 0.5.3: Fixed a bug that caused the dispatch limit to have no effect.
 * 0.5.2: Added pyproject.toml for PEP compliance
 * 0.5.1: `Batch` will now flush on delete, in case you forgot.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def readme():
 
 setup(
     name="slurminade",
-    version="0.5.3",
+    version="0.5.4",
     description="A decorator-based slurm runner",
     long_description=readme(),
     long_description_content_type="text/markdown",

--- a/slurminade/dispatcher.py
+++ b/slurminade/dispatcher.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import typing
+from tempfile import mkstemp
 
 import simple_slurm
 
@@ -20,6 +21,10 @@ from slurminade.conf import _get_conf
 from slurminade.function_map import FunctionMap, get_entry_point
 from slurminade.guard import dispatch_guard
 from slurminade.options import SlurmOptions
+
+
+# MAX_ARG_STRLEN on a Linux system with PAGE_SIZE 4096 is 131072
+DEFAULT_MAX_ARG_LENGTH = 100000
 
 
 class FunctionCall:
@@ -167,6 +172,7 @@ class SlurmDispatcher(Dispatcher):
         super().__init__()
         if not shutil.which("sbatch"):
             raise RuntimeError("Slurm could not be found.")
+        self.max_arg_length = DEFAULT_MAX_ARG_LENGTH
 
     def _create_slurm_api(self, special_slurm_opts):
         conf = _get_conf(special_slurm_opts)
@@ -178,11 +184,8 @@ class SlurmDispatcher(Dispatcher):
     ) -> int:
         dispatch_guard()
         slurm = self._create_slurm_api(options)
-        return slurm.sbatch(
-            f"{sys.executable} -m slurminade.execute"
-            f" {shlex.quote(get_entry_point())}"
-            f" {shlex.quote(json.dumps([f.to_json() for f in funcs]))}"
-        )
+        command = create_slurminade_command(funcs, self.max_arg_length)
+        return slurm.sbatch(command)
 
     def sbatch(self, command: str, conf: dict = None, simple_slurm_kwargs: dict = None):
         dispatch_guard()
@@ -211,15 +214,15 @@ class SubprocessDispatcher(Dispatcher):
     don't want to use slurm.
     Despite using subprocesses, it does not parallelize but works sequential.
     """
+    def __init__(self):
+        super().__init__()
+        self.max_arg_length = DEFAULT_MAX_ARG_LENGTH
 
     def _dispatch(
         self, funcs: typing.Iterable[FunctionCall], options: SlurmOptions
     ) -> int:
-        os.system(
-            f"{sys.executable} -m slurminade.execute"
-            f" {shlex.quote(get_entry_point())}"
-            f" {shlex.quote(json.dumps([f.to_json() for f in funcs]))}"
-        )
+        command = create_slurminade_command(funcs, self.max_arg_length)
+        os.system(command)
         return -1
 
     def srun(self, command: str, conf: dict = None, simple_slurm_kwargs: dict = None):
@@ -257,6 +260,32 @@ class DirectCallDispatcher(Dispatcher):
 
     def is_sequential(self):
         return True
+
+
+def create_slurminade_command(funcs: typing.Iterable[FunctionCall], max_arg_length: int) -> str:
+    """
+    Creates a terminal command that calls the Python module `slurminade.execute` with the
+    provided function calls as an argument. If the total length of the function calls
+    exceeds the maximum allowed length of a command line argument, a temporary file is
+    created to pass the function calls instead.
+    :param funcs: The function calls to be dispatched.
+    :param max_arg_length: The maximum allowed length of a command line argument.
+    :returns: A string representing the command to be executed in the terminal.
+    """
+    command = f"{sys.executable} -m slurminade.execute {shlex.quote(get_entry_point())}"
+
+    # Serialize function calls as JSON
+    serialized_calls = json.dumps([f.to_json() for f in funcs])
+
+    if len(shlex.quote(serialized_calls)) > max_arg_length:
+        # The argument is too long, create temporary file for the JSON
+        fd, filename = mkstemp(prefix="slurminade_", suffix=".json", text=True, dir=".")
+        with os.fdopen(fd, 'w') as f:
+            f.write(serialized_calls)
+        command += f" temp {shlex.quote(filename)}"
+    else:
+        command += f" arg {shlex.quote(serialized_calls)}"
+    return command
 
 
 # The current dispatcher. Use with `get_dispatcher` and `set_dispatcher`.

--- a/slurminade/execute.py
+++ b/slurminade/execute.py
@@ -2,36 +2,49 @@
 This module provides the starting point for the slurm node. You do not have to call
 anything of this file yourself.
 """
-
-import sys
+import os
 
 from .guard import prevent_distribution
 from .function import SlurmFunction
 from .function_map import set_entry_point
 import json
+import sys
+
+
+def parse_args():
+    batch_file_path = sys.argv[1]  # the file with the code (function definition)
+    # determine whether function calls are provided as an argument or in a temp file.
+    mode = sys.argv[2]
+    if mode == "arg":
+        function_calls = json.loads(sys.argv[3])
+    elif mode == "temp":
+        with open(sys.argv[3]) as f:
+            function_calls = json.load(f)
+        os.remove(sys.argv[3])  # delete the temp file
+    else:
+        raise ValueError("Unknown function call mode. Expected 'arg' or 'temp'.")
+    assert isinstance(function_calls, list), "Expected a list of dicts"
+    return batch_file_path, function_calls
 
 
 def main():
-
     prevent_distribution()  # make sure, the code on the node does not distribute itself.
-    batch_file = sys.argv[1]  # the file with the code (function definition)
-    instructions = sys.argv[2]
-    # Load the code
+    batch_file, function_calls = parse_args()
+
     set_entry_point(batch_file)
     with open(batch_file, "r") as f:
         code = "".join(f.readlines())
 
-        # Workaround as otherwise __name__ is not defined
-        global __name__
-        __name__ = None
+    # Workaround as otherwise __name__ is not defined
+    global __name__
+    __name__ = None
 
-        glob = dict(globals())
-        glob["__file__"] = batch_file
-        exec(code, glob)
+    glob = dict(globals())
+    glob["__file__"] = batch_file
+    exec(code, glob)
+
     # Execute the functions
-    argd = json.loads(instructions)
-    assert isinstance(argd, list), "Should be a list of dicts"
-    for fc in argd:
+    for fc in function_calls:
         SlurmFunction.call(fc["func_id"], *fc.get("args", []), **fc.get("kwargs", {}))
 
 

--- a/tests/test_create_command.py
+++ b/tests/test_create_command.py
@@ -1,0 +1,40 @@
+import os
+import shlex
+import unittest
+from pathlib import Path
+
+import slurminade
+from slurminade.dispatcher import create_slurminade_command, FunctionCall
+
+
+@slurminade.slurmify()
+def f(s):
+    pass
+
+
+def delete_file(file):
+    if os.path.exists(file):
+        os.remove(file)
+
+
+class TestCreateCommand(unittest.TestCase):
+    def test_create_long_command(self):
+        dummy_call = FunctionCall(f.func_id, ["." * 100], {})
+        command = create_slurminade_command([dummy_call], 100)
+        args = shlex.split(command)
+        path = Path(args[-1])
+        self.assertEqual(args[-2], "temp")
+        # check creation of temporary file
+        self.assertTrue(Path(path).is_file())
+        delete_file(path)
+
+    def test_create_short_command(self):
+        dummy_call = FunctionCall(f.func_id, [""], {})
+        command = create_slurminade_command([dummy_call], 100000)
+        args = shlex.split(command)
+        self.assertEqual(args[-2], "arg")
+
+
+
+
+

--- a/tests/test_create_command.py
+++ b/tests/test_create_command.py
@@ -1,0 +1,41 @@
+import os
+import shlex
+import unittest
+from pathlib import Path
+
+import os
+import slurminade
+from slurminade.dispatcher import create_slurminade_command, FunctionCall
+
+
+@slurminade.slurmify()
+def f(s):
+    pass
+
+
+def delete_file(file):
+    if os.path.exists(file):
+        os.remove(file)
+
+
+class TestCreateCommand(unittest.TestCase):
+    def test_create_long_command(self):
+        dummy_call = FunctionCall(f.func_id, ["." * 100], {})
+        command = create_slurminade_command([dummy_call], 100)
+        args = shlex.split(command)
+        path = Path(args[-1])
+        self.assertEqual(args[-2], "temp")
+        # check creation of temporary file
+        self.assertTrue(Path(path).is_file())
+        delete_file(path)
+
+    def test_create_short_command(self):
+        dummy_call = FunctionCall(f.func_id, [""], {})
+        command = create_slurminade_command([dummy_call], 100000)
+        args = shlex.split(command)
+        self.assertEqual(args[-2], "arg"
+
+
+
+
+

--- a/tests/test_create_command.py
+++ b/tests/test_create_command.py
@@ -1,4 +1,3 @@
-import os
 import shlex
 import unittest
 from pathlib import Path
@@ -6,35 +5,39 @@ from pathlib import Path
 import slurminade
 from slurminade.dispatcher import create_slurminade_command, FunctionCall
 
+test_file_path = Path("./f_test_file.txt")
+
 
 @slurminade.slurmify()
 def f(s):
-    pass
-
-
-def delete_file(file):
-    if os.path.exists(file):
-        os.remove(file)
+    with open(test_file_path, "w") as file:
+        file.write(s)
 
 
 class TestCreateCommand(unittest.TestCase):
     def test_create_long_command(self):
-        dummy_call = FunctionCall(f.func_id, ["." * 100], {})
-        command = create_slurminade_command([dummy_call], 100)
+        test_call = FunctionCall(f.func_id, ["." * 100], {})
+        command = create_slurminade_command([test_call], 100)
         args = shlex.split(command)
         path = Path(args[-1])
         self.assertEqual(args[-2], "temp")
         # check creation of temporary file
         self.assertTrue(Path(path).is_file())
-        delete_file(path)
+        path.unlink(missing_ok=True)    # delete the file
 
     def test_create_short_command(self):
-        dummy_call = FunctionCall(f.func_id, [""], {})
-        command = create_slurminade_command([dummy_call], 100000)
+        test_call = FunctionCall(f.func_id, [""], {})
+        command = create_slurminade_command([test_call], 100000)
         args = shlex.split(command)
         self.assertEqual(args[-2], "arg")
 
-
-
-
-
+    def test_dispatch_with_temp_file(self):
+        dispatcher = slurminade.SubprocessDispatcher()
+        dispatcher.max_arg_length = 1
+        slurminade.set_dispatcher(dispatcher)
+        s = "test"
+        f.distribute(s)
+        self.assertTrue(test_file_path.is_file())
+        with open(test_file_path, "r") as file:
+            self.assertEqual(file.readline(), s)
+        test_file_path.unlink(missing_ok=True)   # delete the file

--- a/tests/test_create_command.py
+++ b/tests/test_create_command.py
@@ -32,6 +32,8 @@ class TestCreateCommand(unittest.TestCase):
         self.assertEqual(args[-2], "arg")
 
     def test_dispatch_with_temp_file(self):
+        slurminade.set_entry_point(__file__)
+        test_file_path.unlink(missing_ok=True)
         dispatcher = slurminade.SubprocessDispatcher()
         dispatcher.max_arg_length = 1
         slurminade.set_dispatcher(dispatcher)


### PR DESCRIPTION
I added a size limit for the serialized function calls to the `SlurmDispatcher` and `SubprocessDispatcher`. If the length of the argument exceeds the limit the JSON data is saved to a temporary file in the cwd. 
To ensure the uniqueness of filenames  `tempfile.mkstemp()` is used. Referring to the Slurm job id would be preferable, but since the temp file is created before the job is scheduled I am not sure how to do it.
The `DEFAULT_MAX_ARG_LENGTH` is set to 100.000. The maximum length of a command line argument on a  Linux system with `PAGE_SIZE=4096` is 131.072, which is what usually limits us.
`execute.py` is responsible for deleting the temp files after reading.